### PR TITLE
correct collide functions + add needed files to be able to install the package via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tests/pgzhelper.py
 tests/__pycache__
 __pycache__
+*.egg-info

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,24 @@
+# pgzhelper
+Pygame Zero Helper was originally created to enhance Pygame Zero with additional capabilities that were available in Scratch (eg. move_forward, point_towards, distance_to), but it has since evolved to include a large number of collision detection functions that are useful in games.
+
+The capabilities provided by pgzhelp can be roughly divided into...
+
+* Actor enhancements
+    * Additional capabilities for a Pygame Zero Actor
+    * Examples: 
+        * Movements: move_forward, point_towards
+        * Animation: images, animate, fps
+        * Image: scale, flip_x, flip_y
+* Collision detection
+    * Detect collision between points, lines, circles, rect (AABB), rect (OBB)
+    * Examples:
+        * Collide.circle_line() : Check if a circle is colliding with a line
+        * Collide.obb_points() : Check if an OBB rect is colliding with any of the given points
+* Utility
+    * Small utility functions
+    * Examples:
+        * For Pygame Zero: toggle_fullscreen, hide_mouse
+        * Movement and directions: distance_to, direction_to
+
+## Wiki
+Please see the wiki on github for more details.

--- a/pgzhelper.py
+++ b/pgzhelper.py
@@ -1277,11 +1277,11 @@ class Actor(Actor):
 
   def obb_collidepoint(self, x, y):
     w, h = self._orig_surf.get_size()
-    return Collide.obb_point(self.x, self.y, w, h, self._angle, x, y)
+    return Collide.obb_point(self.centerx, self.centery, w, h, self._angle, x, y)
 
   def obb_collidepoints(self, points):
     w, h = self._orig_surf.get_size()
-    return Collide.obb_points(self.x, self.y, w, h, self._angle, points)
+    return Collide.obb_points(self.centerx, self.centery, w, h, self._angle, points)
 
   @property
   def radius(self):
@@ -1292,16 +1292,16 @@ class Actor(Actor):
     self._radius = radius
 
   def circle_collidepoints(self, points):
-    return Collide.circle_points(self.x, self.y, self._radius, points)
+    return Collide.circle_points(self.centerx, self.centery, self._radius, points)
 
   def circle_collidepoint(self, x, y):
-    return Collide.circle_point(self.x, self.y, self._radius, x, y)
+    return Collide.circle_point(self.centerx, self.centery, self._radius, x, y)
 
   def circle_collidecircle(self, actor):
-    return Collide.circle_circle(self.x, self.y, self._radius, actor.x, actor.y, actor._radius)
+    return Collide.circle_circle(self.centerx, self.centery, self._radius, actor.centerx, actor.centery, actor._radius)
 
   def circle_colliderect(self, actor):
-    return Collide.circle_rect(self.x, self.y, self._radius, actor.left, actor.top, actor.width, actor.height)
+    return Collide.circle_rect(self.centerx, self.centery, self._radius, actor.left, actor.top, actor.width, actor.height)
 
   def draw(self):
     game.screen.blit(self._surf, self.topleft)

--- a/pgzhelper.py
+++ b/pgzhelper.py
@@ -1301,7 +1301,7 @@ class Actor(Actor):
     return Collide.circle_circle(self.centerx, self.centery, self._radius, actor.centerx, actor.centery, actor._radius)
 
   def circle_colliderect(self, actor):
-    return Collide.circle_rect(self.centerx, self.centery, self._radius, actor.left, actor.top, actor.width, actor.height)
+    return Collide.circle_rect(self.centerx, self.centery, self._radius, actor.centerx, actor.centery, actor.width, actor.height)
 
   def draw(self):
     game.screen.blit(self._surf, self.topleft)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+import io
+import os.path
+from setuptools import setup
+import pgzero
+
+path = os.path.join(os.path.dirname(__file__), 'README.rst')
+with io.open(path, encoding='utf8') as f:
+    LONG_DESCRIPTION = f.read()
+
+install_requires = [
+    "pgzero>=1.2"
+]
+
+setup(
+    name='pgzhelper',
+    version=pgzero.__version__,
+    description="Pygame Zero Helper enhance Pygame Zero with additional capabilities",
+    long_description=LONG_DESCRIPTION,
+    author='Cort',
+    author_email='cort@cortscorner.net',
+    url='https://www.aposteriori.com.sg/pygame-zero-helper/',
+    include_package_data=True,
+    py_modules=['pgzhelper'],
+    install_requires=install_requires,
+    python_requires='>=3.7',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Education',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Education',
+        'Topic :: Games/Entertainment',
+    ]
+)


### PR DESCRIPTION
*correct collide functions to use centerx, centery instead of x, y. indeed x, y return the anchor point which is not what we need when anchor is not center,center

*correct circle_colliderect

*add needed files to be able to install the package via pip