### PR TITLE
correct small error in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import io
 import os.path
 from setuptools import setup
-import pgzero
 
 path = os.path.join(os.path.dirname(__file__), 'README.rst')
 with io.open(path, encoding='utf8') as f:
@@ -13,7 +12,7 @@ install_requires = [
 
 setup(
     name='pgzhelper',
-    version=pgzero.__version__,
+    version='1.0b0',
     description="Pygame Zero Helper enhance Pygame Zero with additional capabilities",
     long_description=LONG_DESCRIPTION,
     author='Cort',


### PR DESCRIPTION
correct small error in setup which was using unnecessary pgzero 

can you put the correct version number in it. currently i set it 1.0b0

currently you can install with pip using cmd:
pip install git+https://github.com/QuirkyCort/pgzhelper

if you want users to be able to install via "pip install pgzhelper"
you must upload the package to the Python Package Index
it let you do it if you want to do it, see https://packaging.python.org/en/latest/tutorials/packaging-projects/
chapters "Generating distribution archives",  "Uploading the distribution archives"