### PR TITLE
correct default radius of Actor

### DIFF
--- a/pgzhelper.py
+++ b/pgzhelper.py
@@ -1361,7 +1361,7 @@ class Actor(Actor):
   def radius(self):
     if self._radius is None:
       w,h = self._unrotated_size()
-      self._radius = min(w, h)
+      self._radius = min(w, h) * .5
     return self._radius
 
   @radius.setter


### PR DESCRIPTION
default radius of Actor should be half of the minimum unrotated sizes
also if the scale is later changed the default radius should be automatically adapt.